### PR TITLE
feat: update app timeout

### DIFF
--- a/src/services/item/index.ts
+++ b/src/services/item/index.ts
@@ -3,6 +3,7 @@ import { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
 
 import {
+  APPS_JWT_EXPIRATION_IN_MINUTES,
   APPS_JWT_SECRET,
   APPS_PUBLISHER_ID,
   APP_ITEMS_PREFIX,
@@ -48,6 +49,7 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   // this needs to execute before 'create()' and 'updateOne()' are called
   // because graaspApps extends the schemas
   fastify.register(graaspApps, {
+    jwtExpiration: APPS_JWT_EXPIRATION_IN_MINUTES,
     jwtSecret: APPS_JWT_SECRET,
     prefix: APP_ITEMS_PREFIX,
     publisherId: APPS_PUBLISHER_ID,

--- a/src/services/item/plugins/app/constants.ts
+++ b/src/services/item/plugins/app/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_JWT_EXPIRATION = 30;
+export const DEFAULT_JWT_EXPIRATION = 360;
 
 export const APPS_TEMPLATE_PATH_PREFIX = 'apps/templates/';
 export const THUMBNAILS_ROUTE = '/thumbnails';

--- a/src/services/item/plugins/app/docs/guide.md
+++ b/src/services/item/plugins/app/docs/guide.md
@@ -49,7 +49,7 @@ The response will contain `token` you will be using to request your app's data.
 
 3. **Use the API**: From now on you can freely use your token to access the API and fetch various data. See the [API Documentation](./api.md).
 
-4. **Refetch the token**: The token might expire. In this case, redo step 2.
+4. **Refetch the token**: The token might expire. In this case, redo step 2. Graasp app API tokens are long-lived by default so embedded experiments can run for hours on the same page, but apps should still be prepared to request a new token if needed.
 
 ## File Upload
 

--- a/src/services/item/plugins/app/test/index.test.ts
+++ b/src/services/item/plugins/app/test/index.test.ts
@@ -1,4 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
+import { decode } from 'jsonwebtoken';
 import { v4 } from 'uuid';
 
 import { FastifyInstance } from 'fastify';
@@ -11,7 +12,7 @@ import build, {
   unmockAuthenticate,
 } from '../../../../../../test/app';
 import { assertIsDefined } from '../../../../../utils/assertions';
-import { APP_ITEMS_PREFIX } from '../../../../../utils/config';
+import { APPS_JWT_EXPIRATION_IN_MINUTES, APP_ITEMS_PREFIX } from '../../../../../utils/config';
 import { Guest } from '../../../../itemLogin/entities/guest';
 import { Member } from '../../../../member/entities/member';
 import { expectAccount, saveMember } from '../../../../member/test/fixtures/members';
@@ -145,6 +146,37 @@ describe('Apps Plugin Tests', () => {
           payload: { origin: chosenApp.url, key: chosenApp.key },
         });
         expect(response.json().token).toBeTruthy();
+      });
+
+      it('Issues app tokens with the configured expiration window', async () => {
+        if (!actor) {
+          throw new Error('actor is not defined');
+        }
+        const { item } = await testUtils.saveApp({ url: chosenApp.url, member: actor });
+
+        const response = await app.inject({
+          method: HttpMethod.Post,
+          url: `${APP_ITEMS_PREFIX}/${item.id}/api-access-token`,
+          payload: { origin: chosenApp.url, key: chosenApp.key },
+        });
+
+        const { token } = response.json();
+        const payload = decode(token);
+
+        expect(typeof payload).toEqual('object');
+        if (!payload || typeof payload === 'string') {
+          throw new Error('token payload is invalid');
+        }
+
+        const { exp, iat } = payload;
+
+        expect(typeof exp).toEqual('number');
+        expect(typeof iat).toEqual('number');
+        if (typeof exp !== 'number' || typeof iat !== 'number') {
+          throw new Error('token timestamps are missing');
+        }
+
+        expect(exp - iat).toEqual(APPS_JWT_EXPIRATION_IN_MINUTES * 60);
       });
 
       it('Incorrect params throw bad request', async () => {

--- a/src/services/item/plugins/app/types.ts
+++ b/src/services/item/plugins/app/types.ts
@@ -1,6 +1,6 @@
 export interface AppsPluginOptions {
   jwtSecret: string;
-  /** In minutes. Defaults to 30 (minutes) */
+  /** In minutes. Defaults to 360 (6 hours). */
   jwtExpiration?: number;
 
   publisherId: string;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -288,6 +288,9 @@ if (!process.env.APPS_JWT_SECRET) {
   throw new Error('APPS_JWT_SECRET is not defined');
 }
 export const APPS_JWT_SECRET = process.env.APPS_JWT_SECRET;
+export const APPS_JWT_EXPIRATION_IN_MINUTES = process.env.APPS_JWT_EXPIRATION_IN_MINUTES
+  ? +process.env.APPS_JWT_EXPIRATION_IN_MINUTES
+  : 360;
 
 // Graasp websockets
 export const REDIS_HOST = process.env.REDIS_HOST;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App API tokens now support configurable expiration periods with an extended default validity of 360 minutes (6 hours).

* **Documentation**
  * Updated authentication guide with information on token longevity characteristics.

* **Tests**
  * Added tests to validate token expiration configuration and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->